### PR TITLE
Initial Mavenlink ide prefs setup

### DIFF
--- a/pref_sources/RubyMine/templates/Capybara.xml
+++ b/pref_sources/RubyMine/templates/Capybara.xml
@@ -2,13 +2,11 @@
   <template name="sos" value="save_and_open_screenshot" description="Save and open screenshot" toReformat="true" toShortenFQNames="true">
     <context>
       <option name="RUBY" value="true" />
-      <option name="CUCUMBER_FEATURE_FILE" value="true" />
     </context>
   </template>
   <template name="sop" value="save_and_open_page" description="Save and open page" toReformat="true" toShortenFQNames="true">
     <context>
       <option name="RUBY" value="true" />
-      <option name="CUCUMBER_FEATURE_FILE" value="true" />
     </context>
   </template>
 </templateSet>

--- a/pref_sources/RubyMine/templates/Ruby.xml
+++ b/pref_sources/RubyMine/templates/Ruby.xml
@@ -1,40 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="Ruby">
   <template name="ps" value="puts &quot;===&gt; $VAR_COPY$: #{($VAR$).inspect}&quot;" description="output for debugging" toReformat="false" toShortenFQNames="true">
     <variable name="VAR" expression="" defaultValue="var" alwaysStopAt="true" />
     <variable name="VAR_COPY" expression="VAR" defaultValue="" alwaysStopAt="false" />
     <context>
-      <option name="HTML_TEXT" value="false" />
-      <option name="HTML" value="false" />
-      <option name="XSL_TEXT" value="false" />
-      <option name="XML" value="false" />
       <option name="RUBY" value="true" />
-      <option name="RHTML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="JAVA_SCRIPT" value="false" />
-      <option name="SQL" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
-      <option name="HAML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="rle" value="Rails.logger.error &quot;===&gt; $VAR_COPY$: #{($VAR$).inspect}&quot;" description="Rails logger error output for debugging" toReformat="false" toShortenFQNames="true">
     <variable name="VAR" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="VAR_COPY" expression="VAR" defaultValue="" alwaysStopAt="false" />
     <context>
-      <option name="HTML_TEXT" value="false" />
-      <option name="HTML" value="false" />
-      <option name="XSL_TEXT" value="false" />
-      <option name="XML" value="false" />
       <option name="RUBY" value="true" />
-      <option name="RHTML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="JAVA_SCRIPT" value="false" />
-      <option name="SQL" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
-      <option name="HAML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
 </templateSet>
-

--- a/pref_sources/RubyMine/templates/user.xml
+++ b/pref_sources/RubyMine/templates/user.xml
@@ -1,20 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="user">
   <template name="pl" value="puts [__FILE__,__LINE__].join &quot;:&quot;" description="puts file name and line number" toReformat="false" toShortenFQNames="true">
     <context>
-      <option name="HTML_TEXT" value="false" />
-      <option name="HTML" value="false" />
-      <option name="XSL_TEXT" value="false" />
-      <option name="XML" value="false" />
       <option name="RUBY" value="true" />
-      <option name="RHTML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="JAVA_SCRIPT" value="false" />
-      <option name="SQL" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
-      <option name="HAML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
 </templateSet>
-

--- a/pref_sources/RubyMine/templates/webOS.xml
+++ b/pref_sources/RubyMine/templates/webOS.xml
@@ -1,16 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="webOS">
   <template name="assist" value="function $CLASS$() {&#10;  $END$&#10;}&#10;&#10;$CLASS$.prototype.setup = function() {&#10;};&#10;&#10;$CLASS$.prototype.activate = function() {&#10;};&#10;&#10;$CLASS$.prototype.deactivate = function() {&#10;};&#10;&#10;$CLASS$.prototype.cleanup = function() {&#10;};&#10;&#10;$CLASS$.prototype.onStageActivate = function() {&#10;};&#10;&#10;$CLASS$.prototype.onStageDeactivate = function() {&#10;};&#10;" description="block out a Palm webOS scene assistant" toReformat="true" toShortenFQNames="true">
     <variable name="CLASS" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="CSS" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="proto" value="$CLASS$.prototype.$PROPERTY$ = function($ARGS$) {&#10;  $END$&#10;};&#10;" description="add a new function to a JavaScript object's prototype" toReformat="true" toShortenFQNames="true">
@@ -18,15 +10,7 @@
     <variable name="PROPERTY" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="ARGS" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="CSS" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
 </templateSet>
-

--- a/pref_sources/WebStorm/templates/jasmine.xml
+++ b/pref_sources/WebStorm/templates/jasmine.xml
@@ -3,151 +3,67 @@
     <variable name="A" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="B" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="jit" value="// DEPRECATED: you can now use 'it&lt;TAB&gt;'&#10;it(&quot;should $B$&quot;, function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
     <variable name="B" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="jwait" value="// DEPRECATED: you can now use 'wait&lt;TAB&gt;'&#10;waitsFor(1000, function() {&#10;  $END$&#10;}, &quot;$A$&quot;);&#10;&#10;" description="Jasmine waits block" toReformat="true" toShortenFQNames="true">
     <variable name="A" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="jrun" value="// DEPRECATED: you can now use 'run&lt;TAB&gt;'&#10;runs(function() {&#10;  $END$&#10;});" description="Jasmine runs block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="jbef" value="// DEPRECATED: you can now use 'bef&lt;TAB&gt;'&#10;beforeEach(function() {&#10;  $END$&#10;});" description="a Jasmine beforeEach block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="jaft" value="// DEPRECATED: you can now use 'aft&lt;TAB&gt;'&#10;afterEach(function() {&#10;  $END$&#10;});" description="a Jasmine afterEach block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="aft" value="afterEach(function() {&#10;  $END$&#10;});" description="a Jasmine afterEach block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="bef" value="beforeEach(function() {&#10;  $END$&#10;});" description="a Jasmine beforeEach block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="desc" value="describe(&quot;$A$&quot;, function () {&#10;  $END$&#10;});" description="Jasmine describe block, with one it" toReformat="true" toShortenFQNames="true">
     <variable name="A" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="it" value="it(&quot;$B$&quot;, function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
     <variable name="B" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="run" value="runs(function() {&#10;  $END$&#10;});" description="Jasmine runs block" toReformat="true" toShortenFQNames="true">
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
   <template name="wait" value="waitsFor(1000, function() {&#10;  $END$&#10;}, &quot;$A$&quot;);&#10;&#10;" description="Jasmine waits block" toReformat="true" toShortenFQNames="true">
     <variable name="A" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
-      <option name="HTML" value="false" />
-      <option name="XML" value="false" />
-      <option name="CSS" value="false" />
-      <option name="CUCUMBER_FEATURE_FILE" value="false" />
       <option name="JAVA_SCRIPT" value="true" />
-      <option name="RUBY" value="false" />
-      <option name="RHTML" value="false" />
-      <option name="OTHER" value="false" />
     </context>
   </template>
 </templateSet>


### PR DESCRIPTION
- Remove many of the Ruby template options

  These were all removed automatically the first time we tried to change any of the prefs. Not sure if we want any of these or not, but it seems that there's something about our current RubyMine setup causing these to not be present, and therefore they get removed from the preferences.