### PR TITLE
Swap `Duplicate Line` with `Select Next Occurrence` shortcut

### DIFF
--- a/pref_sources/RubyMine/keymaps/Mavenlink Synced.xml
+++ b/pref_sources/RubyMine/keymaps/Mavenlink Synced.xml
@@ -3,6 +3,7 @@
     <keyboard-shortcut first-keystroke="meta alt left" />
     <mouse-shortcut keystroke="button4" />
   </action>
+  <action id="CompareTwoFiles" />
   <action id="Console.TableResult.NavigateAction">
     <keyboard-shortcut first-keystroke="f4" />
   </action>
@@ -16,6 +17,9 @@
   <action id="EditBreakpoint" />
   <action id="EditSource">
     <keyboard-shortcut first-keystroke="f4" />
+  </action>
+  <action id="EditorDuplicate">
+    <keyboard-shortcut first-keystroke="shift meta d" />
   </action>
   <action id="EditorIndentLineOrSelection">
     <keyboard-shortcut first-keystroke="meta close_bracket" />
@@ -79,7 +83,7 @@
   </action>
   <action id="SelectNextOccurrence">
     <keyboard-shortcut first-keystroke="ctrl g" />
-    <keyboard-shortcut first-keystroke="shift meta d" />
+    <keyboard-shortcut first-keystroke="meta d" />
   </action>
   <action id="ShowNavBar">
     <keyboard-shortcut first-keystroke="alt home" />
@@ -103,3 +107,4 @@
   <action id="Uml.ShowDiff" />
   <action id="ViewBreakpoints" />
 </keymap>
+

--- a/pref_sources/RubyMine/keymaps/Mavenlink Synced.xml
+++ b/pref_sources/RubyMine/keymaps/Mavenlink Synced.xml
@@ -107,4 +107,3 @@
   <action id="Uml.ShowDiff" />
   <action id="ViewBreakpoints" />
 </keymap>
-


### PR DESCRIPTION
Addresses https://github.com/mavenlink/mavenlink_ide_prefs/pull/4#issuecomment-253272990

Makes it consistent with other editors to reduce friction when switching editors

There was an extra `Compare Files` command that was mapped to `meta d` which intefered with the mapping. This was removed since it doesn't seem to be frequently used