### PR TITLE
A few fixes from setting up a new RubyMine config

### DIFF
--- a/pref_sources/RubyMine/codestyles/Pivotal.xml
+++ b/pref_sources/RubyMine/codestyles/Pivotal.xml
@@ -1,14 +1,9 @@
-<code_scheme name="Pivotal">
+<code_scheme name="Pivotal" version="173">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
     </value>
   </option>
   <JSCodeStyleSettings>
@@ -72,6 +67,7 @@
   <codeStyleSettings language="ruby">
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
     <option name="SPACE_WITHIN_BRACES" value="true" />
+    <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
     <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="2" />
       <option name="USE_RELATIVE_INDENTS" value="false" />

--- a/pref_sources/WebStorm/templates/jasmine.xml
+++ b/pref_sources/WebStorm/templates/jasmine.xml
@@ -33,23 +33,23 @@
       <option name="JAVA_SCRIPT" value="true" />
     </context>
   </template>
-  <template name="aft" value="afterEach(function() {&#10;  $END$&#10;});" description="a Jasmine afterEach block" toReformat="true" toShortenFQNames="true">
+  <template name="aft" value="afterEach(function () {&#10;  $END$&#10;});" description="a Jasmine afterEach block" toReformat="true" toShortenFQNames="true">
     <context>
       <option name="JAVA_SCRIPT" value="true" />
     </context>
   </template>
-  <template name="bef" value="beforeEach(function() {&#10;  $END$&#10;});" description="a Jasmine beforeEach block" toReformat="true" toShortenFQNames="true">
+  <template name="bef" value="beforeEach(function () {&#10;  $END$&#10;});" description="a Jasmine beforeEach block" toReformat="true" toShortenFQNames="true">
     <context>
       <option name="JAVA_SCRIPT" value="true" />
     </context>
   </template>
-  <template name="desc" value="describe(&quot;$A$&quot;, function () {&#10;  $END$&#10;});" description="Jasmine describe block, with one it" toReformat="true" toShortenFQNames="true">
+  <template name="desc" value="describe('$A$', () =&gt; {&#10;  $END$&#10;});" description="Jasmine describe block, with one it" toReformat="true" toShortenFQNames="true">
     <variable name="A" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="JAVA_SCRIPT" value="true" />
     </context>
   </template>
-  <template name="it" value="it(&quot;$B$&quot;, function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
+  <template name="it" value="it('$B$', function() {&#10;  $END$&#10;});&#10;" description="Jasmine it block" toReformat="true" toShortenFQNames="true">
     <variable name="B" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="JAVA_SCRIPT" value="true" />


### PR DESCRIPTION

- RubyMine on the machine we were using somehow got broken, so
  we wiped the preferences folder and reimported. These changes
  are a few of the manual tweaks we had to make that we think
  are reasonable for all machines to have.

- Setup Jasmine live templates to follow our lint rules. Optimize
  for most common case.
- Set space around block brackets.
- We think RubyMine automatically removed a few lines of unnecessary
config.

Signed-off-by: Gary McKellar <gmckellar@mavenlink.com>